### PR TITLE
Support multiple file uploads for events

### DIFF
--- a/mod_insert_event/helper.php
+++ b/mod_insert_event/helper.php
@@ -38,24 +38,46 @@ class ModInsertEventHelper
             // ID dell'evento appena inserito
             $idEvento = $db->insertid();
 
-            // Se è stata caricata un'immagine, inserisci anche in hermes_immagini
-            if (!empty($data['immagine_nome']) && !empty($data['immagine_percorso'])) {
-                $query = $db->getQuery(true);
+            if (!empty($data['immagini'])) {
+                foreach ($data['immagini'] as $img) {
+                    $query = $db->getQuery(true);
 
-                $columns = ['id_evento', 'nome_file', 'percorso_file'];
-                $values = [
-                    (int) $idEvento,
-                    $db->quote($data['immagine_nome']),
-                    $db->quote($data['immagine_percorso'])
-                ];
+                    $columns = ['id_evento', 'nome_file', 'percorso_file'];
+                    $values = [
+                        (int) $idEvento,
+                        $db->quote($img['nome']),
+                        $db->quote($img['percorso'])
+                    ];
 
-                $query
-                    ->insert($db->quoteName('hermes_immagini'))
-                    ->columns($db->quoteName($columns))
-                    ->values(implode(',', $values));
+                    $query
+                        ->insert($db->quoteName('hermes_immagini'))
+                        ->columns($db->quoteName($columns))
+                        ->values(implode(',', $values));
 
-                $db->setQuery($query);
-                $db->execute();
+                    $db->setQuery($query);
+                    $db->execute();
+                }
+            }
+
+            if (!empty($data['files'])) {
+                foreach ($data['files'] as $file) {
+                    $query = $db->getQuery(true);
+
+                    $columns = ['id_evento', 'nome_file', 'percorso_file'];
+                    $values = [
+                        (int) $idEvento,
+                        $db->quote($file['nome']),
+                        $db->quote($file['percorso'])
+                    ];
+
+                    $query
+                        ->insert($db->quoteName('hermes_files'))
+                        ->columns($db->quoteName($columns))
+                        ->values(implode(',', $values));
+
+                    $db->setQuery($query);
+                    $db->execute();
+                }
             }
 
             return true;

--- a/mod_insert_event/mod_insert_event.php
+++ b/mod_insert_event/mod_insert_event.php
@@ -10,24 +10,68 @@ $input = Factory::getApplication()->input;
 $moduleId = $module->id;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $input->get('mod_id') == $moduleId) {
-	$data = [
-		'data'      => $input->getString('data'),
-		'ora'       => $input->getString('ora'),
-		'tipo'      => $input->getString('tipo'),
-		'area'      => $input->getString('area'),
-		'stazione'  => $input->getString('stazione'),
-		'componente'=> $input->getString('componente'),
-	    'note'=> $input->getString('note'),
+        $data = [
+                'data'      => $input->getString('data'),
+                'ora'       => $input->getString('ora'),
+                'tipo'      => $input->getString('tipo'),
+                'area'      => $input->getString('area'),
+                'stazione'  => $input->getString('stazione'),
+                'componente'=> $input->getString('componente'),
+            'note'=> $input->getString('note'),
         'Md'=> $input->getString('Md'),
         'profondita'=> $input->getString('profondita'),
         'lat'=> $input->getString('lat'),
         'lon'=> $input->getString('lon')
            ];
 
+        $data['immagini'] = [];
+        if (!empty($_FILES['immagine']) && is_array($_FILES['immagine']['name'])) {
+                $uploadDir = 'images/eventi/';
+                $uploadPath = JPATH_ROOT . '/' . $uploadDir;
+                if (!is_dir($uploadPath)) {
+                        mkdir($uploadPath, 0755, true);
+                }
+                foreach ($_FILES['immagine']['name'] as $k => $nome) {
+                        if ($_FILES['immagine']['error'][$k] === UPLOAD_ERR_OK) {
+                                $tmpName = $_FILES['immagine']['tmp_name'][$k];
+                                $filename = basename($nome);
+                                $target = $uploadPath . $filename;
+                                if (move_uploaded_file($tmpName, $target)) {
+                                        $data['immagini'][] = [
+                                                'nome' => $filename,
+                                                'percorso' => $uploadDir . $filename
+                                        ];
+                                }
+                        }
+                }
+        }
+
+        $data['files'] = [];
+        if (!empty($_FILES['file_evento']) && is_array($_FILES['file_evento']['name'])) {
+                $uploadDir = 'files/eventi/';
+                $uploadPath = JPATH_ROOT . '/' . $uploadDir;
+                if (!is_dir($uploadPath)) {
+                        mkdir($uploadPath, 0755, true);
+                }
+                foreach ($_FILES['file_evento']['name'] as $k => $nome) {
+                        if ($_FILES['file_evento']['error'][$k] === UPLOAD_ERR_OK) {
+                                $tmpName = $_FILES['file_evento']['tmp_name'][$k];
+                                $filename = basename($nome);
+                                $target = $uploadPath . $filename;
+                                if (move_uploaded_file($tmpName, $target)) {
+                                        $data['files'][] = [
+                                                'nome' => $filename,
+                                                'percorso' => $uploadDir . $filename
+                                        ];
+                                }
+                        }
+                }
+        }
+
 echo '<pre>Dati ricevuti in PHP:</pre>';
 print_r($data);
-  
-	$esito = ModInsertEventHelper::salvaEvento($data);
+
+        $esito = ModInsertEventHelper::salvaEvento($data);
 echo '<pre>Funzione eseguita. Esito: ' . var_export($esito, true) . '</pre>';
 }
 

--- a/mod_insert_event/tmpl/default.php
+++ b/mod_insert_event/tmpl/default.php
@@ -143,16 +143,23 @@
   <div class="form-group row">
     <label for="immagine" class="col-4 col-form-label">Immagine</label>
     <div class="col-8">
-        <input id="immagine" name="immagine" type="file" accept="image/*" class="form-control">
+        <input id="immagine" name="immagine[]" type="file" accept="image/*" class="form-control" multiple>
     </div>
-</div>
+  </div>
+
+  <div class="form-group row">
+    <label for="file_evento" class="col-4 col-form-label">File evento</label>
+    <div class="col-8">
+        <input id="file_evento" name="file_evento[]" type="file" class="form-control" multiple>
+    </div>
+  </div>
 
   <div class="form-group row">
     <label for="note" class="col-4 col-form-label">Note</label>
     <div class="col-8">
         <input id="note" name="note" type="text" class="form-control">
     </div>
-</div>
+  </div>
   
   
   <div class="form-group row">


### PR DESCRIPTION
## Summary
- Allow multiple image and attachment selection in event form
- Process uploaded images and files and save metadata
- Insert uploaded image and file records into `hermes_immagini` and `hermes_files`

## Testing
- `php -l mod_insert_event/tmpl/default.php`
- `php -l mod_insert_event/mod_insert_event.php`
- `php -l mod_insert_event/helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0249407448326a37276f11d2cc544